### PR TITLE
Refactor: improve speed of preparing

### DIFF
--- a/preparing/src/main/kotlin/AppDataPreparer.kt
+++ b/preparing/src/main/kotlin/AppDataPreparer.kt
@@ -57,20 +57,18 @@ object AppDataPreparer {
                 val inputStream: InputStream = object {}.javaClass.classLoader.getResourceAsStream("jyutping.txt") ?: error("Can not load jyutping.txt")
                 val sourceLines = inputStream.bufferedReader().use { it.readLines().filter { line -> line.isNotBlank() } }
                 val insertEntryCommand: String = "INSERT INTO jyutpingtable (word, romanization) VALUES (?, ?);"
-                connection.prepareStatement(insertEntryCommand).use { statement ->
-                        for (line in sourceLines) {
-                                val badLineFormat = "bad line format: $line"
-                                val parts = line.split(PresetString.TAB)
-                                if (parts.size != 2) error(badLineFormat)
-                                val word = parts[0]
-                                val romanization = parts[1]
-                                statement.setString(1, word)
-                                statement.setString(2, romanization)
-                                statement.executeUpdate()
-                        }
+                println("Inserting ${sourceLines.size} jyutping entries...")
+                val inserted = batchInsert(connection, insertEntryCommand, sourceLines) { statement, line ->
+                        val badLineFormat = "bad line format: $line"
+                        val parts = line.split(PresetString.TAB)
+                        if (parts.size != 2) error(badLineFormat)
+                        val word = parts[0]
+                        val romanization = parts[1]
+                        statement.setString(1, word)
+                        statement.setString(2, romanization)
                 }
                 connection.close()
-                println("Inserted jyutping entries successfully.")
+                println("Inserted jyutping entries successfully: $inserted")
         }
 
         private fun createCollocationTable(url: String) {
@@ -83,22 +81,20 @@ object AppDataPreparer {
                 val inputStream: InputStream = object {}.javaClass.classLoader.getResourceAsStream("collocation.txt") ?: error("Can not load collocation.txt")
                 val sourceLines = inputStream.bufferedReader().use { it.readLines().filter { line -> line.isNotBlank() } }
                 val insertEntryCommand: String = "INSERT INTO collocationtable (word, romanization, collocation) VALUES (?, ?, ?);"
-                connection.prepareStatement(insertEntryCommand).use { statement ->
-                        for (line in sourceLines) {
-                                val badLineFormat = "bad line format: $line"
-                                val parts = line.split(PresetString.TAB)
-                                if (parts.size != 3) error(badLineFormat)
-                                val word = parts[0]
-                                val romanization = parts[1]
-                                val collocation = parts[2]
-                                statement.setString(1, word)
-                                statement.setString(2, romanization)
-                                statement.setString(3, collocation)
-                                statement.executeUpdate()
-                        }
+                println("Inserting ${sourceLines.size} collocation entries...")
+                val insertedColl = batchInsert(connection, insertEntryCommand, sourceLines) { statement, line ->
+                        val badLineFormat = "bad line format: $line"
+                        val parts = line.split(PresetString.TAB)
+                        if (parts.size != 3) error(badLineFormat)
+                        val word = parts[0]
+                        val romanization = parts[1]
+                        val collocation = parts[2]
+                        statement.setString(1, word)
+                        statement.setString(2, romanization)
+                        statement.setString(3, collocation)
                 }
                 connection.close()
-                println("Inserted collocation entries successfully.")
+                println("Inserted collocation entries successfully: $insertedColl")
         }
 
         private fun createDefinitionTable(url: String) {
@@ -109,17 +105,14 @@ object AppDataPreparer {
                 }
                 println("Created definition table successfully.")
                 val entries = UnihanDefinition.generate()
-
                 val insertEntryCommand: String = "INSERT INTO definitiontable (code, definition) VALUES (?, ?);"
-                connection.prepareStatement(insertEntryCommand).use { statement ->
-                        for (entry in entries) {
-                                statement.setInt(1, entry.first)
-                                statement.setString(2, entry.second)
-                                statement.executeUpdate()
-                        }
+                println("Inserting ${entries.size} definition entries...")
+                val insertedDef = batchInsert(connection, insertEntryCommand, entries) { statement, entry ->
+                        statement.setInt(1, entry.first)
+                        statement.setString(2, entry.second)
                 }
                 connection.close()
-                println("Inserted definition entries successfully.")
+                println("Inserted definition entries successfully: $insertedDef")
         }
 
         private fun createYingWaaTable(url: String) {
@@ -132,28 +125,26 @@ object AppDataPreparer {
                 val inputStream: InputStream = object {}.javaClass.classLoader.getResourceAsStream("yingwaa.txt") ?: error("Can not load yingwaa.txt")
                 val sourceLines = inputStream.bufferedReader().use { it.readLines().filter { line -> line.isNotBlank() } }
                 val insertEntryCommand: String = "INSERT INTO yingwaatable (code, word, romanization, pronunciation, pronunciationmark, interpretation) VALUES (?, ?, ?, ?, ?, ?);"
-                connection.prepareStatement(insertEntryCommand).use { statement ->
-                        for (line in sourceLines) {
-                                val badLineFormat = "bad line format: $line"
-                                val parts = line.split(PresetString.TAB)
-                                if (parts.size != 6) error(badLineFormat)
-                                val code = parts[0].toInt()
-                                val word = parts[1]
-                                val romanization = parts[2]
-                                val pronunciation = parts[3]
-                                val pronunciationMark = parts[4]
-                                val interpretation = parts[5]
-                                statement.setInt(1, code)
-                                statement.setString(2, word)
-                                statement.setString(3, romanization)
-                                statement.setString(4, pronunciation)
-                                statement.setString(5, pronunciationMark)
-                                statement.setString(6, interpretation)
-                                statement.executeUpdate()
-                        }
+                println("Inserting ${sourceLines.size} yingwaa entries...")
+                val insertedYw = batchInsert(connection, insertEntryCommand, sourceLines) { statement, line ->
+                        val badLineFormat = "bad line format: $line"
+                        val parts = line.split(PresetString.TAB)
+                        if (parts.size != 6) error(badLineFormat)
+                        val code = parts[0].toInt()
+                        val word = parts[1]
+                        val romanization = parts[2]
+                        val pronunciation = parts[3]
+                        val pronunciationMark = parts[4]
+                        val interpretation = parts[5]
+                        statement.setInt(1, code)
+                        statement.setString(2, word)
+                        statement.setString(3, romanization)
+                        statement.setString(4, pronunciation)
+                        statement.setString(5, pronunciationMark)
+                        statement.setString(6, interpretation)
                 }
                 connection.close()
-                println("Inserted yingwaa entries successfully.")
+                println("Inserted yingwaa entries successfully: $insertedYw")
         }
 
         private fun createChoHokTable(url: String) {
@@ -166,30 +157,28 @@ object AppDataPreparer {
                 val inputStream: InputStream = object {}.javaClass.classLoader.getResourceAsStream("chohok.txt") ?: error("Can not load chohok.txt")
                 val sourceLines = inputStream.bufferedReader().use { it.readLines().filter { line -> line.isNotBlank() } }
                 val insertEntryCommand: String = "INSERT INTO chohoktable (code, word, romanization, initial, final, tone, faancit) VALUES (?, ?, ?, ?, ?, ?, ?);"
-                connection.prepareStatement(insertEntryCommand).use { statement ->
-                        for (line in sourceLines) {
-                                val badLineFormat = "bad line format: $line"
-                                val parts = line.split(PresetString.TAB)
-                                if (parts.size != 7) error(badLineFormat)
-                                val code = parts[0].toInt()
-                                val word = parts[1]
-                                val romanization = parts[2]
-                                val initial = parts[3]
-                                val final = parts[4]
-                                val tone = parts[5]
-                                val faancit = parts[6]
-                                statement.setInt(1, code)
-                                statement.setString(2, word)
-                                statement.setString(3, romanization)
-                                statement.setString(4, initial)
-                                statement.setString(5, final)
-                                statement.setString(6, tone)
-                                statement.setString(7, faancit)
-                                statement.executeUpdate()
-                        }
+                println("Inserting ${sourceLines.size} chohok entries...")
+                val insertedCh = batchInsert(connection, insertEntryCommand, sourceLines) { statement, line ->
+                        val badLineFormat = "bad line format: $line"
+                        val parts = line.split(PresetString.TAB)
+                        if (parts.size != 7) error(badLineFormat)
+                        val code = parts[0].toInt()
+                        val word = parts[1]
+                        val romanization = parts[2]
+                        val initial = parts[3]
+                        val final = parts[4]
+                        val tone = parts[5]
+                        val faancit = parts[6]
+                        statement.setInt(1, code)
+                        statement.setString(2, word)
+                        statement.setString(3, romanization)
+                        statement.setString(4, initial)
+                        statement.setString(5, final)
+                        statement.setString(6, tone)
+                        statement.setString(7, faancit)
                 }
                 connection.close()
-                println("Inserted chohok entries successfully.")
+                println("Inserted chohok entries successfully: $insertedCh")
         }
 
         private fun createFanWanTable(url: String) {
@@ -202,34 +191,32 @@ object AppDataPreparer {
                 val inputStream: InputStream = object {}.javaClass.classLoader.getResourceAsStream("fanwan.txt") ?: error("Can not load fanwan.txt")
                 val sourceLines = inputStream.bufferedReader().use { it.readLines().filter { line -> line.isNotBlank() } }
                 val insertEntryCommand: String = "INSERT INTO fanwantable (code, word, romanization, initial, final, yamyeung, tone, rhyme, interpretation) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"
-                connection.prepareStatement(insertEntryCommand).use { statement ->
-                        for (line in sourceLines) {
-                                val badLineFormat = "bad line format: $line"
-                                val parts = line.split(PresetString.TAB)
-                                if (parts.size != 9) error(badLineFormat)
-                                val code = parts[0].toInt()
-                                val word = parts[1]
-                                val romanization = parts[2]
-                                val initial = parts[3]
-                                val final = parts[4]
-                                val yamyeung = parts[5]
-                                val tone = parts[6]
-                                val rhyme = parts[7]
-                                val interpretation = parts[8]
-                                statement.setInt(1, code)
-                                statement.setString(2, word)
-                                statement.setString(3, romanization)
-                                statement.setString(4, initial)
-                                statement.setString(5, final)
-                                statement.setString(6, yamyeung)
-                                statement.setString(7, tone)
-                                statement.setString(8, rhyme)
-                                statement.setString(9, interpretation)
-                                statement.executeUpdate()
-                        }
+                println("Inserting ${sourceLines.size} fanwan entries...")
+                val insertedFan = batchInsert(connection, insertEntryCommand, sourceLines) { statement, line ->
+                        val badLineFormat = "bad line format: $line"
+                        val parts = line.split(PresetString.TAB)
+                        if (parts.size != 9) error(badLineFormat)
+                        val code = parts[0].toInt()
+                        val word = parts[1]
+                        val romanization = parts[2]
+                        val initial = parts[3]
+                        val final = parts[4]
+                        val yamyeung = parts[5]
+                        val tone = parts[6]
+                        val rhyme = parts[7]
+                        val interpretation = parts[8]
+                        statement.setInt(1, code)
+                        statement.setString(2, word)
+                        statement.setString(3, romanization)
+                        statement.setString(4, initial)
+                        statement.setString(5, final)
+                        statement.setString(6, yamyeung)
+                        statement.setString(7, tone)
+                        statement.setString(8, rhyme)
+                        statement.setString(9, interpretation)
                 }
                 connection.close()
-                println("Inserted fanwan entries successfully.")
+                println("Inserted fanwan entries successfully: $insertedFan")
         }
 
         private fun createGwongWanTable(url: String) {
@@ -242,45 +229,43 @@ object AppDataPreparer {
                 val inputStream: InputStream = object {}.javaClass.classLoader.getResourceAsStream("gwongwan.txt") ?: error("Can not load gwongwan.txt")
                 val sourceLines = inputStream.bufferedReader().use { it.readLines().filter { line -> line.isNotBlank() } }
                 val insertEntryCommand: String = "INSERT INTO gwongwantable (code, word, rhyme, subrhyme, subrhymeserial, subrhymenumber, upper, lower, initial, rounding, division, rhymeclass, repeating, tone, interpretation) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,?, ?, ?, ?, ?, ?);"
-                connection.prepareStatement(insertEntryCommand).use { statement ->
-                        for (line in sourceLines) {
-                                val badLineFormat = "bad line format: $line"
-                                val parts = line.split(",")
-                                if (parts.size != 15) error(badLineFormat)
-                                val code = parts[0].toInt()
-                                val word = parts[1]
-                                val rhyme = parts[2]
-                                val subrhyme = parts[3]
-                                val subrhymeserial = parts[4].toInt()
-                                val subrhymenumber = parts[5].toInt()
-                                val upper = parts[6]
-                                val lower = parts[7]
-                                val initial = parts[8]
-                                val rounding = parts[9]
-                                val division = parts[10]
-                                val rhymeclass = parts[11]
-                                val repeating = parts[12]
-                                val tone = parts[13]
-                                val interpretation = parts[14]
-                                statement.setInt(1, code)
-                                statement.setString(2, word)
-                                statement.setString(3, rhyme)
-                                statement.setString(4, subrhyme)
-                                statement.setInt(5, subrhymeserial)
-                                statement.setInt(6, subrhymenumber)
-                                statement.setString(7, upper)
-                                statement.setString(8, lower)
-                                statement.setString(9, initial)
-                                statement.setString(10, rounding)
-                                statement.setString(11, division)
-                                statement.setString(12, rhymeclass)
-                                statement.setString(13, repeating)
-                                statement.setString(14, tone)
-                                statement.setString(15, interpretation)
-                                statement.executeUpdate()
-                        }
+                println("Inserting ${sourceLines.size} gwongwan entries...")
+                val insertedGw = batchInsert(connection, insertEntryCommand, sourceLines) { statement, line ->
+                        val badLineFormat = "bad line format: $line"
+                        val parts = line.split(",")
+                        if (parts.size != 15) error(badLineFormat)
+                        val code = parts[0].toInt()
+                        val word = parts[1]
+                        val rhyme = parts[2]
+                        val subrhyme = parts[3]
+                        val subrhymeserial = parts[4].toInt()
+                        val subrhymenumber = parts[5].toInt()
+                        val upper = parts[6]
+                        val lower = parts[7]
+                        val initial = parts[8]
+                        val rounding = parts[9]
+                        val division = parts[10]
+                        val rhymeclass = parts[11]
+                        val repeating = parts[12]
+                        val tone = parts[13]
+                        val interpretation = parts[14]
+                        statement.setInt(1, code)
+                        statement.setString(2, word)
+                        statement.setString(3, rhyme)
+                        statement.setString(4, subrhyme)
+                        statement.setInt(5, subrhymeserial)
+                        statement.setInt(6, subrhymenumber)
+                        statement.setString(7, upper)
+                        statement.setString(8, lower)
+                        statement.setString(9, initial)
+                        statement.setString(10, rounding)
+                        statement.setString(11, division)
+                        statement.setString(12, rhymeclass)
+                        statement.setString(13, repeating)
+                        statement.setString(14, tone)
+                        statement.setString(15, interpretation)
                 }
                 connection.close()
-                println("Inserted gwongwan entries successfully.")
+                println("Inserted gwongwan entries successfully: $insertedGw")
         }
 }

--- a/preparing/src/main/kotlin/Cangjie.kt
+++ b/preparing/src/main/kotlin/Cangjie.kt
@@ -31,14 +31,12 @@ data class Cangjie(
                                 connection.createStatement().execute(createTableCommand)
                                 val insertCommand: String = "INSERT INTO cangjie5table (word, cangjie) VALUES (?, ?);"
                                 val cangjie5Data = readCangjie5Data()
-                                connection.prepareStatement(insertCommand).use { statement ->
-                                        for (obj in cangjie5Data) {
+                                println("Inserting ${cangjie5Data.size} cangjie5 rows (temp DB)...")
+                                        val inserted = batchInsert(connection, insertCommand, cangjie5Data) { statement, obj ->
                                                 statement.setString(1, obj.first)
                                                 statement.setString(2, obj.second)
-                                                statement.executeUpdate()
                                         }
-                                        statement.close()
-                                }
+                                        println("Inserted cangjie5 rows (temp DB): $inserted")
                                 val createIndexCommand: String = "CREATE INDEX cangjie5wordindex ON cangjie5table(word);"
                                 connection.createStatement().execute(createIndexCommand)
                         }
@@ -47,14 +45,12 @@ data class Cangjie(
                                 connection.createStatement().execute(createTableCommand)
                                 val insertCommand: String = "INSERT INTO cangjie3table (word, cangjie) VALUES (?, ?);"
                                 val cangjie3Data = readCangjie3Data()
-                                connection.prepareStatement(insertCommand).use { statement ->
-                                        for (obj in cangjie3Data) {
-                                                statement.setString(1, obj.first)
-                                                statement.setString(2, obj.second)
-                                                statement.executeUpdate()
-                                        }
-                                        statement.close()
+                                println("Inserting ${cangjie3Data.size} cangjie3 rows (temp DB)...")
+                                val inserted3 = batchInsert(connection, insertCommand, cangjie3Data) { statement, obj ->
+                                        statement.setString(1, obj.first)
+                                        statement.setString(2, obj.second)
                                 }
+                                println("Inserted cangjie3 rows (temp DB): $inserted3")
                                 val createIndexCommand: String = "CREATE INDEX cangjie3wordindex ON cangjie3table(word);"
                                 connection.createStatement().execute(createIndexCommand)
                         }

--- a/preparing/src/main/kotlin/DbConstants.kt
+++ b/preparing/src/main/kotlin/DbConstants.kt
@@ -1,0 +1,4 @@
+package org.jyutping.preparing
+
+// Shared DB batch size to avoid overwhelming weak machines
+const val BATCH_SIZE: Int = 1000

--- a/preparing/src/main/kotlin/DbUtils.kt
+++ b/preparing/src/main/kotlin/DbUtils.kt
@@ -1,0 +1,40 @@
+package org.jyutping.preparing
+
+import java.sql.Connection
+import java.sql.PreparedStatement
+
+/**
+ * Execute batched inserts with a shared BATCH_SIZE and transactional semantics.
+ * Returns the number of rows inserted.
+ */
+fun <T> batchInsert(connection: Connection, insertSql: String, rows: Iterable<T>, bind: (PreparedStatement, T) -> Unit): Int {
+    connection.autoCommit = false
+    var inserted = 0
+    try {
+        connection.prepareStatement(insertSql).use { statement ->
+            var batchCount = 0
+            for (row in rows) {
+                bind(statement, row)
+                statement.addBatch()
+                inserted++
+                batchCount++
+                if (batchCount >= BATCH_SIZE) {
+                    statement.executeBatch()
+                    statement.clearBatch()
+                    batchCount = 0
+                }
+            }
+            if (batchCount > 0) {
+                statement.executeBatch()
+                statement.clearBatch()
+            }
+        }
+        connection.commit()
+    } catch (e: Exception) {
+        connection.rollback()
+        throw e
+    } finally {
+        connection.autoCommit = true
+    }
+    return inserted
+}

--- a/preparing/src/main/kotlin/Quick.kt
+++ b/preparing/src/main/kotlin/Quick.kt
@@ -31,14 +31,12 @@ data class Quick(
                                 connection.createStatement().execute(createTableCommand)
                                 val insertCommand: String = "INSERT INTO cangjie5table (word, cangjie) VALUES (?, ?);"
                                 val cangjie5Data = readCangjie5Data()
-                                connection.prepareStatement(insertCommand).use { statement ->
-                                        for (obj in cangjie5Data) {
-                                                statement.setString(1, obj.first)
-                                                statement.setString(2, obj.second)
-                                                statement.executeUpdate()
-                                        }
-                                        statement.close()
+                                println("Inserting ${cangjie5Data.size} cangjie5 rows (temp DB)...")
+                                val inserted = batchInsert(connection, insertCommand, cangjie5Data) { statement, obj ->
+                                        statement.setString(1, obj.first)
+                                        statement.setString(2, obj.second)
                                 }
+                                println("Inserted cangjie5 rows (temp DB): $inserted")
                                 val createIndexCommand: String = "CREATE INDEX cangjie5wordindex ON cangjie5table(word);"
                                 connection.createStatement().execute(createIndexCommand)
                         }
@@ -47,14 +45,12 @@ data class Quick(
                                 connection.createStatement().execute(createTableCommand)
                                 val insertCommand: String = "INSERT INTO cangjie3table (word, cangjie) VALUES (?, ?);"
                                 val cangjie3Data = readCangjie3Data()
-                                connection.prepareStatement(insertCommand).use { statement ->
-                                        for (obj in cangjie3Data) {
-                                                statement.setString(1, obj.first)
-                                                statement.setString(2, obj.second)
-                                                statement.executeUpdate()
-                                        }
-                                        statement.close()
+                                println("Inserting ${cangjie3Data.size} cangjie3 rows (temp DB)...")
+                                val inserted3 = batchInsert(connection, insertCommand, cangjie3Data) { statement, obj ->
+                                        statement.setString(1, obj.first)
+                                        statement.setString(2, obj.second)
                                 }
+                                println("Inserted cangjie3 rows (temp DB): $inserted3")
                                 val createIndexCommand: String = "CREATE INDEX cangjie3wordindex ON cangjie3table(word);"
                                 connection.createStatement().execute(createIndexCommand)
                         }

--- a/preparing/src/main/kotlin/Stroke.kt
+++ b/preparing/src/main/kotlin/Stroke.kt
@@ -28,14 +28,12 @@ data class Stroke(
 
                         val insertCommand: String = "INSERT INTO stroketable (word, stroke) VALUES (?, ?);"
                         val strokeData = readStrokeData()
-                        connection.prepareStatement(insertCommand).use { statement ->
-                                for (obj in strokeData) {
-                                        statement.setString(1, obj.first)
-                                        statement.setString(2, obj.second)
-                                        statement.executeUpdate()
-                                }
-                                statement.close()
+                        println("Inserting ${strokeData.size} stroke rows (temp DB)...")
+                        val inserted = batchInsert(connection, insertCommand, strokeData) { statement, obj ->
+                                statement.setString(1, obj.first)
+                                statement.setString(2, obj.second)
                         }
+                        println("Inserted stroke rows (temp DB): $inserted")
                         val createIndexCommand: String = "CREATE INDEX strokewordindex ON stroketable(word);"
                         connection.createStatement().execute(createIndexCommand)
 

--- a/preparing/src/main/kotlin/UnihanDefinition.kt
+++ b/preparing/src/main/kotlin/UnihanDefinition.kt
@@ -14,14 +14,12 @@ object UnihanDefinition {
 
                 val insertCommand: String = "INSERT INTO definitiontable (word, definition) VALUES (?, ?);"
                 val strokeData = readDefinitionData()
-                connection.prepareStatement(insertCommand).use { statement ->
-                        for (obj in strokeData) {
-                                statement.setString(1, obj.first)
-                                statement.setString(2, obj.second)
-                                statement.executeUpdate()
-                        }
-                        statement.close()
+                println("Inserting ${strokeData.size} definition rows (temp DB)...")
+                val inserted = batchInsert(connection, insertCommand, strokeData) { statement, obj ->
+                        statement.setString(1, obj.first)
+                        statement.setString(2, obj.second)
                 }
+                println("Inserted definition rows (temp DB): $inserted")
                 val createIndexCommand: String = "CREATE INDEX definitionwordindex ON definitiontable(word);"
                 connection.createStatement().execute(createIndexCommand)
 


### PR DESCRIPTION
- Improves the performance and reliability of database population by replacing individual row insertions with a batched approach.
- Add general until function for batching for each dbs (DbUtils.kt)
- Add more helpful logs for perparing
- Add a constants kt for batch_size for devs to change if ram insufficient or encounter other issues(DbConstants.kt)

Basically, turns from a long wait(thought it hangs, but was running) , to a very short amount of time(7s on my pc)

Note: Readme updates might be needed to included, the settings for batchSize for devs.
