### PR TITLE
Enhance: override onEvaluateFullscreenMode to prevevnt fullscreen UI to be shown in some scenario

### DIFF
--- a/app/src/main/java/org/jyutping/jyutping/JyutpingInputMethodService.kt
+++ b/app/src/main/java/org/jyutping/jyutping/JyutpingInputMethodService.kt
@@ -92,9 +92,7 @@ class JyutpingInputMethodService: LifecycleInputMethodService(),
          * button) in landscape. Returning false forces the IME to keep the input view
          * anchored (inline) instead of using the extract/fullscreen UI.
          */
-        override fun onEvaluateFullscreenMode(): Boolean {
-                return false
-        }
+        override fun onEvaluateFullscreenMode() = false
 
         override fun onCreate() {
                 super.onCreate()


### PR DESCRIPTION
You may want to take a look for this one. I believe the most simple way for current situation is just `return false` for this `onEvaluateFullscreenMode` .
This may not be the best solution in long term, but I see multiple opensource keyboard set that to false too. So maybe it is good enough.

Here are an example on if we don't set it to false what would happened:
This is a screenshot of not setting it to false, trying to type on whatsapp chat in landscape mode.
![Screenshot_20251017_014554_com whatsapp](https://github.com/user-attachments/assets/84809bb9-e310-4608-82ef-4867cd488ef5)
VS
How it looks like with it setting to false
Virtual:
![Screenshot_20251017_015555](https://github.com/user-attachments/assets/50ee8e3e-cc21-47e7-8583-3f91dde4738f)
Physical:
![Screenshot_20251017_015534](https://github.com/user-attachments/assets/055cea62-2fe6-471d-b656-9dc752dc1f1f)
